### PR TITLE
Added default values to .labelSizeVariant mixin

### DIFF
--- a/legos/label.less
+++ b/legos/label.less
@@ -42,7 +42,8 @@
 
 // -------------------- Descendands --------------------
 //label size
-.labelSizeVariant(@paddingVertical; @paddingHorizontal; @fontSize; @lineHeight; @borderRadius) {
+
+.labelSizeVariant(@paddingVertical; @paddingHorizontal; @fontSize; @lineHeight: @label-lineHeight; @borderRadius: @label-borderRadius) {
 	.padding-vertical(@paddingVertical);
 	.padding-horizontal(@paddingHorizontal);
 	.font-size(@fontSize);


### PR DESCRIPTION
Added default values to line height and border radius in the .labelSizeVariant mixin because of an error in the implementation lego which only passed three parameters.
