### PR TITLE
Fixed height mixin using in textbox fix

### DIFF
--- a/baseline/baseline.mixins.less
+++ b/baseline/baseline.mixins.less
@@ -213,3 +213,12 @@
 .right(@units) when (ispixel(@units)) {
 	right: @baseline * (round(@units / @baseline));
 }
+
+// height and line-height mixins. Deprecated?
+.lineHeight-calculatedFromFontSize(@fontSize, @baseFontSize: @base-fontSize, @baseLineHeight: @base-lineHeight) {
+	line-height: round(@baseLineHeight * (@fontSize / @baseFontSize)) + 0px;
+}
+
+.height-calculatedFromFontSize(@fontSize, @baseFontSize: @base-fontSize, @baseLineHeight: @base-lineHeight) {
+	height: round(@baseLineHeight * (@fontSize / @baseFontSize)) + 0px;
+}

--- a/mixins.less
+++ b/mixins.less
@@ -111,15 +111,6 @@
 	}
 }
 
-// Deprecated
-.lineHeight-calculatedFromFontSize(@fontSize, @baseFontSize: @base-fontSize, @baseLineHeight: @base-lineHeight) {
-	line-height: round(@baseLineHeight * (@fontSize / @baseFontSize)) + 0px;
-}
-
-.height-calculatedFromFontSize(@fontSize, @baseFontSize: @base-fontSize, @baseLineHeight: @base-lineHeight) {
-	height: round(@baseLineHeight * (@fontSize / @baseFontSize)) + 0px;
-}
-
 //IE6 & 7 support for inline-block
 .inline-block(){
   display: inline-block;


### PR DESCRIPTION
Somehow i let out this bug in the previous version. 
.height-calculatedFromFontSize() should overwrite the height of the element

currently used only in textbox.less
