### PR TITLE
Changed .Button--icon modifier

### DIFF
--- a/legos/button.less
+++ b/legos/button.less
@@ -90,8 +90,13 @@
 	background: none;
 	margin:0;
 	padding:0;
-	min-width:auto;
+	min-width:inherit;
 	border:none;
+
+	&:hover {
+		background: none;
+		color: inherit;
+	}
 }
 
 .Button--link() {


### PR DESCRIPTION
Changed .Button--icon modifier. Used min-width:inherit instead of min-width:auto because it didn't work in chrome. Added &:hover effects to override the default behavior from the core .Button lego.
