### PR TITLE
Removed caret-like code for the progress-bar ballons.

### DIFF
--- a/legos/progress-bar.less
+++ b/legos/progress-bar.less
@@ -105,29 +105,6 @@
 	z-index: 1;
 	width: @progress-balloon-width;
 	margin-left: 0 - (@progress-balloon-width / 2);
-
-	&:before,
-	&:after {
-		bottom: 100%;
-		left: 50%;
-		border: solid transparent;
-		content: " ";
-		height: 0;
-		width: 0;
-		position: absolute;
-	}
-
-	&:before {
-		border-bottom-color: @progress-borderColor;
-		margin-left: 0 - (@progress-balloon-caretSize + 2);
-		border-width: @progress-balloon-caretSize + 2;
-	}
-
-	&:after {
-		border-bottom-color: @progress-balloon-bgColor;
-		margin-left: -@progress-balloon-caretSize;
-		border-width: @progress-balloon-caretSize;
-	}
 }
 
 .Progress-label() {


### PR DESCRIPTION
Caret lego should be used in markup instead.
