### PR TITLE
Fixed selectbox icon size

### DIFF
--- a/legos/selectbox.less
+++ b/legos/selectbox.less
@@ -104,7 +104,7 @@
 
 	&:after {
 		font-size: @fontSize;
-		.lineHeight-calculatedFromFontSize(@fontSize, @selectbox-fontSize, @selectbox-lineHeight);
+		line-height: inherit;
 	}
 
 	.Selectbox-input {


### PR DESCRIPTION
16px is too big now with the new fonts. 
I will create a pull request a bit later so we have the new fonts on the vendor also.
