### PR TITLE
nav-tabs margin fix

### DIFF
--- a/legos/nav.less
+++ b/legos/nav.less
@@ -244,6 +244,7 @@
 
 	.Nav-item {
 		display: inline-block;
+		margin-right: @nav--tab-marginRight;
 
 		&.is-active {
 			.Nav-link {
@@ -258,7 +259,6 @@
 	.Nav-link,
 	.Nav-link:visited {
 		background: @nav--tab-item-background;
-		margin-right: @nav--tab-marginRight;
 		border: @nav--tab-border;
 		padding: @nav--tab-link-padding;
 		line-height: @nav--tab-link-lineHeight;


### PR DESCRIPTION
Added margin right to li element instead of <a/> so the outline looks good on focus.